### PR TITLE
refactor(Meta): 更新 MySql列类型映射

### DIFF
--- a/src/Meta/MySql/Column.php
+++ b/src/Meta/MySql/Column.php
@@ -30,7 +30,7 @@ class Column implements \Reliese\Meta\Column
      */
     public static $mappings = [
         'string' => ['varchar', 'text', 'string', 'char', 'enum', 'set', 'tinytext', 'mediumtext', 'longtext', 'longblob', 'mediumblob', 'tinyblob', 'blob'],
-        'datetime' => ['datetime', 'year', 'date', 'time', 'timestamp'],
+        'datetime:Y-m-d H:i:s' => ['datetime', 'year', 'date', 'time', 'timestamp'],
         'int' => ['bigint', 'int', 'integer', 'tinyint', 'smallint', 'mediumint'],
         'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
         'boolean' => ['bit']


### PR DESCRIPTION
- 将 'datetime' 类型映射更改为 'datetime:Y-m-d H:i:s'，以支持更精确的时间格式
- 此修改提高了日期时间类型数据的兼容性和准确性